### PR TITLE
Basic Custom Field Setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": "^7.2"
+    "php": "^7.2",
+    "ext-json": "*",
+    "psr/http-message": "1.1"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",

--- a/snakey-forms.php
+++ b/snakey-forms.php
@@ -16,18 +16,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use SnakeyForms\PostTypes\SnakeyForm;
-
 // Initialize global values.
 const SNKFORMS_PREFIX = 'snkfrm';
 
 // Plugin path constants.
-const SNKFORMS_THEME_PATH     = __DIR__;
-const SNKFORMS_THEME_PHP_PATH = SNKFORMS_THEME_PATH . '/src/php';
-const SNKFORMS_CORE_PATH      = SNKFORMS_THEME_PHP_PATH . '/Core';
+const SNKFORMS_PLUGIN_PATH      = __DIR__;
+const SNKFORMS_PLUGIN_PHP_PATH  = SNKFORMS_PLUGIN_PATH . '/src/php';
+const SNKFORMS_PLUGIN_TEMPLATES = SNKFORMS_PLUGIN_PATH . '/templates/';
 
 // Set up dependencies.
-require_once SNKFORMS_THEME_PATH . '/vendor/autoload.php';
+require_once SNKFORMS_PLUGIN_PATH . '/vendor/autoload.php';
 
 // Initialize if there were no collisions found.
 if ( ! class_exists( 'SnakeyForms' ) ) {

--- a/src/php/FormEditor/FieldSettings/FieldEditor.php
+++ b/src/php/FormEditor/FieldSettings/FieldEditor.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Field editor file
+ *
+ * @package snakey-forms/plugin
+ * @since 0.0.1
+ */
+
+/**
+ * Field editor controller class
+ */
+class FieldEditor {
+
+}

--- a/src/php/FormEditor/FormEditor.php
+++ b/src/php/FormEditor/FormEditor.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Custom Form Editor class template file.
+ *
+ * @package snakey-forms/plugin
+ * @since 0.0.1
+ */
+
+namespace SnakeyForms\FormEditor;
+
+use SnakeyForms\FormEditor\FormFields\Interfaces\I_FormField;
+use SnakeyForms\FormEditor\FormFields\TextField;
+
+/**
+ * Custom form editor class primarily for SneakyForm cpt.
+ */
+class FormEditor {
+
+	// Private Fields.
+
+	/**
+	 * Array of available fields.
+	 *
+	 * @var I_FormField[] $r_fields
+	 */
+	private $r_fields;
+
+	/**
+	 * Array of existing form fields.
+	 *
+	 * @var array $form_fields
+	 */
+	private $form_fields;
+
+
+	// Initialization Methods.
+
+	/**
+	 * Initializes instance of the class.
+	 */
+	public function init(): void {
+		// Get the list of registered fields.
+		$this->r_fields = apply_filters( SNKFORMS_PREFIX . '_registered_fields', $this->register_default_fields() );
+
+		// TODO: Test data change with the real values later.
+		$test_data = [
+			[
+				'type'  => 'text',
+				'ref'   => null,
+				'state' => [
+					'name' => 'field_text',
+					// Populate state with settings.
+				],
+			],
+		];
+		// Prototype data of the field.
+		$this->form_fields = $this->parse_selected_field_states( $test_data, $this->r_fields );
+
+	}
+
+
+	// Private Methods.
+
+	/**
+	 * Registers default form fields provided by the plugin.
+	 *
+	 * @return I_FormField[] array of the form fields.
+	 */
+	private function register_default_fields(): array {
+		// An array of registered fields.
+		$r_fields = [];
+		// Create an array of class references for the available fields.
+		$text_field = new TextField();
+		$text_field->init();
+		$r_fields[] = $text_field;
+
+		// Return the list of registered fields.
+		return $r_fields;
+	}
+
+	/**
+	 * Parses data about selected form fields.
+	 *
+	 * @param array $form_data Saved form data.
+	 * @param array $r_fields  Registered form fields.
+	 *
+	 * @return array Parsed array data with references to their field type objects.
+	 */
+	private function parse_selected_field_states( array $form_data, array $r_fields ): array {
+		return array_map(
+			function ( array $s_field ) use ( $r_fields ) {
+				// Go through each of the registered fields to determine the related one.
+				foreach ( $r_fields as $field_obj ) {
+					if ( $s_field['type'] === $field_obj->get_slug() ) {
+						// Set reference for this field to a field object.
+						$s_field['ref'] =& $field_obj;
+						// Break the loop.
+						break;
+					}
+				}
+
+				return $s_field;
+			},
+			$form_data
+		);
+	}
+
+
+	// Public Methods.
+
+	/**
+	 * Displays form content for post editor.
+	 */
+	public function display_form_editor_content(): void {
+		foreach ( $this->form_fields as $field_data ) {
+			$field_data['ref']->render_field_content( $field_data['state'] );
+		}
+	}
+
+	/**
+	 * Displays selector area with possible fields.
+	 */
+	public function display_field_shop(): void {
+
+	}
+}

--- a/src/php/FormEditor/FormFields/Abstracts/A_GenericField.php
+++ b/src/php/FormEditor/FormFields/Abstracts/A_GenericField.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Generic Field abstract class for implementation by other fields.
+ *
+ * @package snakey-forms/plugin
+ * @since 0.0.1
+ **/
+
+namespace SnakeyForms\FormEditor\FormFields\Abstracts;
+
+use SnakeyForms\FormEditor\FormFields\Interfaces\I_FormField;
+
+/**
+ * Generic Fields abstract class. Extend this class to add custom field types for the form editor.
+ */
+abstract class A_GenericField implements I_FormField {
+
+	// Protected Fields.
+
+	/**
+	 * Field slug name (is unique).
+	 *
+	 * @var string $field_slug
+	 */
+	protected $field_slug;
+
+	/**
+	 * Field display name.
+	 *
+	 * @var string $field_name
+	 */
+	protected $field_name;
+
+
+	// Public Properties.
+
+	/**
+	 * Returns field slug name.
+	 *
+	 * @return string field slug name.
+	 */
+	public function get_slug(): string {
+		return $this->field_slug;
+	}
+
+	/**
+	 * Returns field display name.
+	 *
+	 * @return string field display name.
+	 */
+	public function get_name(): string {
+		return $this->field_name;
+	}
+
+
+	// Initialization Methods.
+
+	/**
+	 * Initializes class instance.
+	 */
+	public function init(): void {
+		// Initialize class hooks.
+		$this->hooks();
+	}
+
+	/**
+	 * Initializes class hooks.
+	 */
+	protected function hooks(): void {
+
+	}
+}

--- a/src/php/FormEditor/FormFields/Interfaces/I_FormField.php
+++ b/src/php/FormEditor/FormFields/Interfaces/I_FormField.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Form Field interface to be implemented.
+ *
+ * @package snakey-forms/plugin
+ * @since 0.0.1
+ */
+
+namespace SnakeyForms\FormEditor\FormFields\Interfaces;
+
+/**
+ * Form Field interface.
+ */
+interface I_FormField {
+
+	// Properties.
+
+	/**
+	 * Returns unique field slug name.
+	 *
+	 * @return string Field slug name.
+	 */
+	public function get_slug(): string;
+
+	/**
+	 * Returns display name of the field.
+	 *
+	 * @return string Field display name.
+	 */
+	public function get_name(): string;
+
+
+	// Methods.
+
+	/**
+	 * Displays field preview view in field selector.
+	 */
+	public function display_field_preview(): void;
+
+	/**
+	 * Displays field content based on its parameters.
+	 *
+	 * @param array $state Parameters of the field.
+	 */
+	public function render_field_content( array $state ): void;
+
+	/**
+	 * Display field editor content.
+	 *
+	 * @param array $state Parameters of the field.
+	 */
+	public function display_field_editor( array $state ): void;
+}

--- a/src/php/FormEditor/FormFields/TextField.php
+++ b/src/php/FormEditor/FormFields/TextField.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Text field for the form editor.
+ *
+ * @package snakey-forms/plugin
+ * @since 0.0.1
+ */
+
+namespace SnakeyForms\FormEditor\FormFields;
+
+use SnakeyForms\FormEditor\FormFields\Abstracts\A_GenericField;
+
+/**
+ * Text field for the form editor.
+ */
+class TextField extends A_GenericField {
+
+	// Initialization Methods.
+
+	/**
+	 * Class initialization method.
+	 */
+	public function init(): void {
+		// Initialize basic field data.
+		$this->field_slug = 'text';
+		$this->field_name = __( 'Text Field', 'snakebytes' );
+
+		parent::init();
+	}
+
+
+	// Public Methods.
+
+	/**
+	 * Displays field preview for the field selector.
+	 */
+	public function display_field_preview(): void {
+		esc_html_e( 'Select: Text Field', 'snakebytes' );
+
+		// TODO: Improve preview for this field.
+	}
+
+	/**
+	 * Displays field content based on its parameters.
+	 *
+	 * @param array $state Parameters of the field.
+	 */
+	public function render_field_content( array $state ): void {
+		$template_path = apply_filters( SNKFORMS_PREFIX . '_field_template_' . $this->field_slug, SNKFORMS_PLUGIN_TEMPLATES . 'fields/text-field.php' );
+		// Load field template if it exists.
+		load_template( $template_path, false, $state );
+	}
+
+	/**
+	 * Display field editor content.
+	 *
+	 * @param array $state Parameters of the field.
+	 */
+	public function display_field_editor( array $state ): void {
+		echo 'text field editor';
+		// TODO: Implement display_field_editor() method.
+	}
+}

--- a/src/php/PostTypes/SnakeyForm.php
+++ b/src/php/PostTypes/SnakeyForm.php
@@ -92,7 +92,9 @@ class SnakeyForm {
 	 * @param \WP_Post $post_obj Edited post object.
 	 */
 	public function render_form_editor_content( \WP_Post $post_obj ): void {
-		// TODO: Initialize form editor.
+		$form_editor_obj = new \SnakeyForms\FormEditor\FormEditor();
+		$form_editor_obj->init();
+		$form_editor_obj->display_form_editor_content();
 	}
 }
 

--- a/templates/fields/text-field.php
+++ b/templates/fields/text-field.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Text Field template
+ *
+ * @package snakey-forms/plugin
+ * @since 0.0.1
+ */
+
+
+// This template requires arguments.
+if ( empty( $args ) ) {
+	return;
+}
+
+?>
+<div class="snkfrm-field">
+	<label for="<?php echo esc_attr( $args['name'] ); ?>" style="<?php echo esc_attr( implode( ';', $args['l-style'] ) ); ?>">
+		<?php echo esc_html( $args['label'] ?? $args['name'] ); ?>
+	</label>
+	<input	name="<?php echo esc_attr( $args['name'] ); ?>" id="<?php echo esc_attr( $args['name'] ); ?>"
+			type="text" class="<?php echo esc_attr( implode( ' ', $args['class'] ?? [] ) ); ?>"
+			style="<?php echo esc_attr( implode( ';', $args['style'] ?? [] ) ); ?>"
+			placeholder="<?php echo esc_attr( $args['placeholder'] ?? '' ); ?>"
+			value="<?php echo esc_attr( $args['value'] ?? '' ); ?>"
+	>
+</div>


### PR DESCRIPTION
[General]
 - Minor improvements to plugin setup.

[Custom Form Post Type]
 - Initial setup of the custom post type.

[Form Fields]
 - Added basic interface and abstract class to utilize by Custom Form cpt.
 - Added prototype 'text' field.

[Field Editor]
 - Set up simple class